### PR TITLE
Update SDK to 5.1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 
 let HUMAN_SDK = Target.binaryTarget(
   name: "HUMAN_SDK",
-  url: "https://github.com/PerimeterX/human-security-ios-sdk/releases/download/5.0.0/HUMAN_SDK.xcframework.zip",
-  checksum: "23a087340fd928d2de35289336e3c01ba04fbb8426463b95be3cd40104422575"
+  url: "https://github.com/PerimeterX/human-security-ios-sdk/releases/download/5.1.0/HUMAN_SDK.xcframework.zip",
+  checksum: "773366867a822a04ffb0327da7ebc1bbe8dddb3e13d2368f97e79cd6d8fe5684"
 )
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install HUMAN SDK using [Swift Package Manager](https://github.com/apple/swif
 Alternatively, you can add the following dependency to your `Package.swift` file:
 
 ```swift
-.package(url: "https://github.com/PerimeterX/human-security-ios-sdk-spm.git", from: "5.0.0")
+.package(url: "https://github.com/PerimeterX/human-security-ios-sdk-spm.git", from: "5.1.0")
 ```
 
 ### Why is there a separate repository for Swift Package Manager support?


### PR DESCRIPTION
## Summary
- Update `Package.swift` binary target URL and checksum for iOS SDK v5.1.0
- Update `README.md` install snippet to `from: "5.1.0"`
- Checksum verified against https://github.com/PerimeterX/human-security-ios-sdk/releases/download/5.1.0/HUMAN_SDK.xcframework.zip

## Test plan
- [ ] Merge PR
- [ ] Tag `5.1.0` on `main` after merge (`git tag 5.1.0 && git push origin --tags`)